### PR TITLE
Deprecate `asyncio_timeout`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-async-timeout = "~=3.0.1"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "94f0f4790efc443878e1340cadba9239cd32309fe8c9c831712d1e757aef1ffa"
+            "sha256": "e1ac82277132512ba749ea8996291af36edddfe42171564b84536e340971a889"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": ">=3.7"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -15,17 +13,7 @@
             }
         ]
     },
-    "default": {
-        "async-timeout": {
-            "hashes": [
-                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
-                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
-            ],
-            "index": "pypi",
-            "markers": "python_full_version >= '3.5.3'",
-            "version": "==3.0.1"
-        }
-    },
+    "default": {},
     "develop": {
         "attrs": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 -i https://pypi.org/simple
-async-timeout==3.0.1 --hash=sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f --hash=sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     name="aiosocketpool",
     version=__version__,  # type: ignore
     packages=find_packages(exclude=["*test*"]),
-    install_requires=["async_timeout>=3.0.1"],
     extras_require={
         "testing": [
             "black>=19.3b0",


### PR DESCRIPTION
## Summary

This PR deprecates `asyncio_timeout` library in favour of native `asyncio.wait_for` functionality.

`asyncio_timeout` library is [deprecated](https://pypi.org/project/async-timeout/) and throws an error when using with Python 3.11

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <aiosocketpool.AsyncTcpConnector object at 0x10cce5350>

    async def connect(self) -> bool:
        """Establish a connection to the remote host.
    
        Returns
        -------
        `True` if the connection was successfully established, raises if not.
        """
        if __debug__:
            logging.debug(f"AsyncTcpConnector: new connection to {self.host}:{self.port}")
    
        loop = asyncio.get_event_loop()
    
>       with async_timeout.timeout(self.timeout):
E       TypeError: 'Timeout' object does not support the context manager protocol
```

Resolves: https://github.com/polyatail/aiosocketpool/issues/4

